### PR TITLE
Fixed link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To use the AH follow these steps.
 ### 1. Clone repo
 
 ``` bash
-git clone git@github.com:8ball030/AutonomousHegician.git
+git clone git@github.com:8ball030/AutonomousHegician
 ```
 
 


### PR DESCRIPTION
Removed ".git" from git clone link in the README